### PR TITLE
Add a sort module

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = exports = function (ctx) {
   'display',
   'groupName',
   'shortcutIcon',
+  'sort',
 ].forEach(function (name) {
   exports[name] = require('./src/' + name);
 });

--- a/src/sort.js
+++ b/src/sort.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Sort the SassDoc data by given criteria.
+ * configuration.
+ */
+module.exports = function display(ctx) {
+  if (!ctx.sort) {
+    return;
+  }
+
+  ctx.data = ctx.data.sort(compareData(ctx.sort));
+};
+
+/**
+ * Get a comparison function for given sort criteria.
+ *
+ * @param {Array} sort
+ * @return {Function}
+ */
+function compareData(sort) {
+  return function (a, b) {
+    for (var i = 0; i < sort; ++i) {
+      var parts = parseCriteria(sort[i]);
+      var key = parts[0];
+      var invert = parts[1];
+
+      var comparison = compare(
+        getComparisonValue(key, a),
+        getComparisonValue(key, b)
+      );
+
+      if (invert) {
+        comparison = invert(comparison);
+      }
+
+      if (comparison) {
+        return comparison;
+      }
+    }
+
+    return 0;
+  };
+}
+
+function getComparisonValue(key, item) {
+  switch (key) {
+    case 'group': return item.group[0].toLowerCase();
+    case 'file': return item.file.path;
+    case 'line': return item.context.line.start;
+    case 'access': return parseAccess(item.access);
+    default: throw new Error('Unknown sort criteria `' + key + '`');
+  }
+}
+
+function parseAccess(access) {
+  switch (access) {
+    case 'public': return 1;
+    case 'private': return 2;
+    default: return 3;
+  }
+}
+
+function parseCriteria(key) {
+    var last = key[key.length - 1];
+    var invert = false;
+
+    if (last === '<' || last === '>') {
+      key = key.substr(0, key.length - 1);
+    }
+
+    if (last === '>') {
+      invert = true;
+    }
+
+    return [key, invert];
+}
+
+function invert(comparison) {
+  return !comparison ? 0 : -1 * comparison;
+}
+
+function compare(a, b) {
+  switch (true) {
+    case a > b: return 1;
+    case a === b: return 0;
+    default: return -1;
+  }
+}


### PR DESCRIPTION
It's now possible for a theme using the sort extra to let users configure the sort order.

Currently supported criteria are group, file, line and access.

The configuration is done with a `sort` context key. It's an array of strings, representing a sort criteria plus an optional sort order. The sort order is determined if the last character is either `>` or `<` (respectively desc and asc).

Example:

```json
{
  "sort": [
    "access",
    "line>",
    "group",
    "file"
  ]
}
```

* See SassDoc/sassdoc#239