### PR TITLE
Add a new `descriptionPath` filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,11 @@ module.exports = exports = function (ctx) {
 };
 
 [
-  'byGroupAndType',
-  'byType',
+  'description',
   'markdown',
   'display',
+  'byGroupAndType',
+  'byType',
   'groupName',
   'shortcutIcon',
 ].forEach(function (name) {

--- a/src/description.js
+++ b/src/description.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var s = require('util').format;
+
+/**
+ * Resolve and load a `descriptionPath` key from config.
+ */
+module.exports = function description(ctx) {
+  if (!ctx.descriptionPath) {
+    return;
+  }
+
+  ctx.description = tryLoadFile(ctx);
+};
+
+function tryLoadFile(ctx) {
+  var desc = ctx.descriptionPath;
+  var filePath = path.resolve(ctx.dir || process.cwd(), desc);
+
+  try {
+    return fs.readFileSync(filePath, { encoding: 'utf8' });
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      ctx.emit('warning', new Error(
+        s('Description file not found: `%s` given.', desc)
+      ));
+    } else {
+      ctx.emit('warning', e);
+    }
+  }
+
+  return false;
+}

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -30,6 +30,10 @@ module.exports = function markdown(ctx) {
     ctx.package.description = md(ctx.package.description);
   }
 
+  if (ctx.description) {
+    ctx.description = md(ctx.description);
+  }
+
   ctx.data.forEach(function (item) {
     if ('description' in item) {
       item.description = marked(item.description);

--- a/test/description.test.js
+++ b/test/description.test.js
@@ -1,0 +1,42 @@
+/* global describe, it */
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var assert = require('assert');
+
+var read = function(p) {
+  return fs.readFileSync(path.join(__dirname, p), { encoding: 'utf8' });
+}
+
+describe('#description', function () {
+  var input = read('./fixture/description/input.md');
+  var expected = read('./fixture/description/expected.md');
+  expected = expected.trim();
+
+  var ctx = {
+    dir: path.join(__dirname, './fixture/description'),
+    descriptionPath: './input.md',
+    data: [],
+  };
+
+  it('should resolve and load a description file', function () {
+    require('../')(ctx, 'description', 'markdown');
+
+    assert.equal(ctx.description, expected);
+  });
+
+  it('should not throw if description file is not found', function () {
+    var called = false;
+    ctx.descriptionPath = 'fail.md';
+    ctx.emit = function () {
+      called = true;
+    };
+
+    assert.doesNotThrow(function () {
+      require('../')(ctx, 'description');
+    });
+    assert.ok(called);
+  });
+
+});

--- a/test/fixture/description/expected.md
+++ b/test/fixture/description/expected.md
@@ -1,0 +1,4 @@
+<h1 id="test">Test</h1>
+<p>Just another test.</p>
+<pre><code>var test = &#39;test&#39;;
+</code></pre>

--- a/test/fixture/description/input.md
+++ b/test/fixture/description/input.md
@@ -1,0 +1,7 @@
+# Test
+
+Just another test.
+
+```
+var test = 'test';
+```


### PR DESCRIPTION
Look in ctx for a `descriptionPath` key coming from config.

Expected key from config is `descriptionPath` and can only be a path.
If the `markdown` filter is enabled the file content will be processed.
`descriptionPath` is then available as `ctx.description`.

The markdown file path must be relative to the config file.
Emit a SassDoc warning on error.

Refs SassDoc/sassdoc-theme-default#66