### PR TITLE
Implement variable aliases resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = exports = function (ctx) {
   'groupName',
   'shortcutIcon',
   'sort',
+  'resolvedVariables',
 ].forEach(function (name) {
   exports[name] = require('./src/' + name);
 });

--- a/src/resolvedVariables.js
+++ b/src/resolvedVariables.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Resolve variables aliases.
+ */
+module.exports = function variablesAliases(ctx) {
+  var cache = {};
+
+  ctx.data
+    .filter(isVariable)
+    .forEach(function (item) {
+      cache[item.context.name] = item.context.value;
+    });
+
+  for (var item in cache) {
+    var value = variableValue(cache[item]);
+
+    if (value) {
+      cache[item] = cache[value[1]];
+    }
+  }
+
+  ctx.data
+    .forEach(function (item) {
+      if (isVariable(item)) {
+        item.resolvedValue = cache[item.context.name];
+      }
+
+      if (item.property) {
+        item.property.forEach(function (prop) {
+          var value = variableValue(prop.default);
+
+          prop.resolvedValue = value ? cache[value[1]] : prop.default;
+        });
+      }
+
+      if (item.parameter) {
+        item.parameter.forEach(function (param) {
+          var value = variableValue(param.default);
+
+          param.resolvedValue = value ? cache[value[1]] : param.default;
+        });
+      }
+    });
+};
+
+/**
+ * Test whether passed item is of type variable.
+ * @param {Object} item
+ * @return {Boolean}
+ */
+function isVariable(item) {
+  return typeof item.context.type === 'string' &&
+         item.context.type.toLowerCase() === 'variable';
+}
+
+/**
+ * Test and extract variables key names.
+ * @param {String} value
+ * @return {Array | null}
+ */
+function variableValue(value) {
+  return /^\s*\$([a-z0-9_-]+)$/i.exec(value);
+}

--- a/test/fixture/resolvedVariables/expected.json
+++ b/test/fixture/resolvedVariables/expected.json
@@ -1,0 +1,121 @@
+{
+  "data": [
+    {
+      "description": "<p>Blue</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "color-blue",
+        "value": "blue"
+      },
+      "type": "Color",
+      "resolvedValue": "blue"
+    },
+    {
+      "description": "<p>Red</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "color-red",
+        "value": "red"
+      },
+      "type": "Color",
+      "resolvedValue": "red"
+    },
+    {
+      "description": "<p>Main color</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "color-main",
+        "value": "$color-blue"
+      },
+      "type": "Color",
+      "resolvedValue": "blue"
+    },
+    {
+      "description": "<p>Alt color</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "color-alt",
+        "value": "$color-red"
+      },
+      "type": "Color",
+      "resolvedValue": "red"
+    },
+    {
+      "description": "<p>Colors map</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "colors-map",
+        "value": "(\n  'green': green,\n  'yellow': yellow,\n  'blue': $color-blue,\n  'red': $color-red,\n  'main': $color-main,\n  'alt': $color-alt,\n)"
+      },
+      "type": "Map",
+      "property": [
+        {
+          "type": "Color",
+          "name": "$colors-map.green",
+          "default": "green",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "green"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.yellow",
+          "default": "yellow",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "yellow"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.blue",
+          "default": "$color-blue",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "blue"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.red",
+          "default": "$color-red",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "red"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.main",
+          "default": "$color-main",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "blue"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.alt",
+          "default": "$color-alt",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "red"
+        }
+      ],
+      "resolvedValue": "(\n  'green': green,\n  'yellow': yellow,\n  'blue': $color-blue,\n  'red': $color-red,\n  'main': $color-main,\n  'alt': $color-alt,\n)"
+    },
+    {
+      "description": "<p>A mixin test</p>\n",
+      "context": {
+        "type": "mixin",
+        "name": "test"
+      },
+      "parameter": [
+        {
+          "type": "Color",
+          "name": "color",
+          "default": "$color-main",
+          "description": "<p>a desc</p>\n",
+          "resolvedValue": "blue"
+        },
+        {
+          "type": "Color",
+          "name": "background",
+          "default": "$color-alt",
+          "description": "<p>a desc</p>\n",
+          "resolvedValue": "red"
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixture/resolvedVariables/input.json
+++ b/test/fixture/resolvedVariables/input.json
@@ -1,0 +1,116 @@
+{
+  "data": [
+    {
+      "description": "<p>Blue</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "color-blue",
+        "value": "blue"
+      },
+      "type": "Color"
+    },
+    {
+      "description": "<p>Red</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "color-red",
+        "value": "red"
+      },
+      "type": "Color"
+    },
+    {
+      "description": "<p>Main color</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "color-main",
+        "value": "$color-blue"
+      },
+      "type": "Color"
+    },
+    {
+      "description": "<p>Alt color</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "color-alt",
+        "value": "$color-red"
+      },
+      "type": "Color"
+    },
+    {
+      "description": "<p>Colors map</p>\n",
+      "context": {
+        "type": "variable",
+        "name": "colors-map",
+        "value": "(\n  'green': green,\n  'yellow': yellow,\n  'blue': $color-blue,\n  'red': $color-red,\n  'main': $color-main,\n  'alt': $color-alt,\n)"
+      },
+      "type": "Map",
+      "property": [
+        {
+          "type": "Color",
+          "name": "$colors-map.green",
+          "default": "green",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "green"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.yellow",
+          "default": "yellow",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "yellow"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.blue",
+          "default": "$color-blue",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "blue"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.red",
+          "default": "$color-red",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "red"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.main",
+          "default": "$color-main",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "blue"
+        },
+        {
+          "type": "Color",
+          "name": "$colors-map.alt",
+          "default": "$color-alt",
+          "description": "<p>A color</p>\n",
+          "resolvedValue": "red"
+        }
+      ]
+    },
+    {
+      "description": "<p>A mixin test</p>\n",
+      "context": {
+        "type": "mixin",
+        "name": "test"
+      },
+      "parameter": [
+        {
+          "type": "Color",
+          "name": "color",
+          "default": "$color-main",
+          "description": "<p>a desc</p>\n",
+          "resolvedValue": "blue"
+        },
+        {
+          "type": "Color",
+          "name": "background",
+          "default": "$color-alt",
+          "description": "<p>a desc</p>\n",
+          "resolvedValue": "red"
+        }
+      ]
+    }
+  ]
+}

--- a/test/resolvedVariables.test.js
+++ b/test/resolvedVariables.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var assert = require('assert');
+
+describe('#resolvedVariables', function () {
+  var resolvedVariables = require('../').resolvedVariables;
+
+  var input = require('./fixture/resolvedVariables/input');
+  var expected = require('./fixture/resolvedVariables/expected');
+
+  resolvedVariables(input);
+
+  it('should match expected ctx', function () {
+    assert.deepEqual(input, expected);
+  });
+
+});


### PR DESCRIPTION
Refs SassDoc/sassdoc-theme-default#78

#### Discuss

1 - Should the `resolvedValue` key be added to all items ? Even if that item value is not an alias.
That would prevent a condition check in themes. It's the current implementation of this PR.

2 - In Sass, you'll need to have the aliased variable declared before using it (no hoisting).

```scss
// Good
$color-blue: blue;
$color-main: $color-blue;
// Boom
$color-main: $color-blue;
$color-blue: blue;
````

So one would need to be careful of the import order if the variables are split between different files.

I think SassDoc partials parsing order is kinda random, so we can't rely on it. We need to build a full index of all vars (`cache`) if we want to be safe.
Hence the two loops on `ctx.data`.

3 - Are there any other place we need implement resolution ? Maps values, params ?


Thoughts ?


